### PR TITLE
Remove `sam publish` command from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,4 @@ jobs:
           pipenv run sam package --template-file .aws-sam/build/template.yaml \
             --s3-bucket $LAMBDA_BUCKET \
             --output-template-file .aws-sam/build/$REPO_NAME.yaml
-        - pipenv run sam publish --template .aws-sam/build/$REPO_NAME.yaml
         - pipenv run aws s3 cp .aws-sam/build/$REPO_NAME.yaml s3://$CFN_BUCKET/$REPO_NAME/$TRAVIS_BRANCH/


### PR DESCRIPTION
We've removed the template metadata, don't publish the template for general public use.