### PR TITLE
Support deploying multiple copies

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -130,7 +130,7 @@ Resources:
     Type: AWS::CloudFront::CachePolicy
     Properties:
       CachePolicyConfig:
-        Name: LambdaCache
+        Name: !Sub "LambdaCache-${ServerlessRestApi}"
         MinTTL: 0
         MaxTTL: !Ref CacheTTL
         DefaultTTL: !Ref CacheTTL


### PR DESCRIPTION
In order to support deploying multiple copies of this stack in the same account, each cache policy needs to have a unique name. Make the cache policy name unique to the stack by appending the name of the auto-generated API resource.
