### PR TITLE
Support returning processed chart of accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ In the event of a cache hit, Cloudfront will return the cached value without tri
 
 ### Query String Parameters
 
+A couple query-string parameters are available to configure response output.
+
 | Query String Parameter | Valid Routes | Description |
 | --- | --- | --- |
-| limit | /tags | Return no more than `limit` valid tags. Must be an integer greater than zero. |
+| filter | /accounts | If defined, process the chart of accounts based on `CodesToOmit` and `CodesToAdd`. |
+| limit | /accounts /tags | Return no more than `limit` valid tags. Must be an integer greater than zero. |
 
 ### Required Secure Parameters
 
@@ -71,12 +74,24 @@ The CloudFormation template also outputs the origin URL behind the CloudFront di
 #### /accounts
 
 The `/accounts` endpoint will return a json string representing a dictionary mapping numeric codes to their names.
-This dictionary represents the raw chart of accounts provided by the upstream API, without any filtering or
-deduplication of codes.
+By default, this dictionary represents the raw chart of accounts provided by the upstream API, without any filtering or
+deduplication of codes; but this can be toggled by defining a 'filter' query-string parameter.
 
 E.g.:
 ```json
-{"000000": "No Program", "990300": "Platform Infrastructure"}
+{
+  "12345600": "Duplicate 1",
+  "12345699": "Duplicate 2",
+  "54321": "Inactive",
+  "99030000": "Platform Infrastructure"
+}
+```
+```json
+{
+  "000000": "No Program",
+  "123456": "Duplicate 1",
+  "990300": "Platform Infrastructure"
+}
 ```
 
 #### /tags
@@ -87,7 +102,11 @@ Values are only generated for currently-active program codes.
 
 E.g.:
 ```json
-["No Program / 000000", "Platform Infrastructure / 990300"]
+[
+  "No Program / 000000",
+  "Duplicate 1 / 123456",
+  "Platform Infrastructure / 990300"
+]
 ```
 
 ### CloudFront Cache

--- a/README.md
+++ b/README.md
@@ -22,15 +22,6 @@ and return a JSON mapping of the data to be stored in Cloudfront for a default o
 
 In the event of a cache hit, Cloudfront will return the cached value without triggering an API gateway event.
 
-### Query String Parameters
-
-A couple query-string parameters are available to configure response output.
-
-| Query String Parameter | Valid Routes | Description |
-| --- | --- | --- |
-| filter | /accounts | If defined, process the chart of accounts based on `CodesToOmit` and `CodesToAdd`. |
-| limit | /accounts /tags | Return no more than `limit` valid tags. Must be an integer greater than zero. |
-
 ### Required Secure Parameters
 
 User credentials for logging in to the finance system are stored as secure parameters with a configurable prefix.
@@ -57,6 +48,23 @@ The following template parameters are set as environment variables in the lambda
 | CodesToOmit | CodesToOmit | List of numeric codes to treat as inactive. |
 | CodesToAdd | CodesToAdd | List of "code:name" strings to add to the active list. |
 
+### Query String Parameters
+
+A couple query-string parameters are available to configure response output.
+
+A `filter` parameter is available for the `/accounts` endpoint to optionally
+process the chart of accounts based on the values of `CodesToOmit` and `CodesToAdd`.
+Defining any non-false value for this parameter will enable it.
+
+A `limit` parameter is available for either endpoint to restrict the number of
+items returned. This value must be a positive integer, a value of zero
+disables the parameter.
+
+| Query String Parameter | Valid Routes | Default Value |
+| --- | --- | --- |
+| filter | /accounts | Undefined (disabled) |
+| limit | /accounts /tags | `0` (disabled) |
+
 ### Triggering
 
 The CloudFormation template will output all available endpoint URLs for triggering the lambda, e.g.:
@@ -78,6 +86,8 @@ By default, this dictionary represents the raw chart of accounts provided by the
 deduplication of codes; but this can be toggled by defining a 'filter' query-string parameter.
 
 E.g.:
+
+`/accounts`
 ```json
 {
   "12345600": "Duplicate 1",
@@ -86,6 +96,8 @@ E.g.:
   "99030000": "Platform Infrastructure"
 }
 ```
+
+`/accounts?filter`
 ```json
 {
   "000000": "No Program",

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The following template parameters are set as environment variables in the lambda
 
 A couple query-string parameters are available to configure response output.
 
-A `filter` parameter is available for the `/accounts` endpoint to optionally
+An `enable_code_filter` parameter is available for the `/accounts` endpoint to optionally
 process the chart of accounts based on the values of `CodesToOmit` and `CodesToAdd`.
 Defining any non-false value for this parameter will enable it.
 
@@ -62,7 +62,7 @@ disables the parameter.
 
 | Query String Parameter | Valid Routes | Default Value |
 | --- | --- | --- |
-| filter | /accounts | Undefined (disabled) |
+| enable\_code\_filter | /accounts | Undefined (disabled) |
 | limit | /accounts /tags | `0` (disabled) |
 
 ### Triggering
@@ -83,7 +83,7 @@ The CloudFormation template also outputs the origin URL behind the CloudFront di
 
 The `/accounts` endpoint will return a json string representing a dictionary mapping numeric codes to their names.
 By default, this dictionary represents the raw chart of accounts provided by the upstream API, without any filtering or
-deduplication of codes; but this can be toggled by defining a 'filter' query-string parameter.
+deduplication of codes; but this can be toggled by defining an 'enable\_code\_filter' query-string parameter.
 
 E.g.:
 
@@ -97,7 +97,7 @@ E.g.:
 }
 ```
 
-`/accounts?filter`
+`/accounts?enable_code_filter`
 ```json
 {
   "000000": "No Program",

--- a/mips_api/__init__.py
+++ b/mips_api/__init__.py
@@ -158,15 +158,18 @@ def process_chart(chart_dict, omit_list, extra_dict):
     return out_chart
 
 def _param_filter_bool(params):
-    return ('filter' in params) and params['filter']
+    if 'filter' in params:
+        if params['filter'].lower() not in [ 'false', 'no', 'off' ]:
+            return True
+    return False
 
 def _param_limit_int(params):
     if 'limit' in params:
         try:
             return int(params['limit'])
-        except TypeError as exc:
+        except ValueError as exc:
             err_str = "QueryStringParameter 'limit' must be an Integer"
-            raise TypeError(err_str) from exc
+            raise ValueError(err_str) from exc
     return 0
 
 def filter_chart(params, raw_chart, omit_list, extra_dict):

--- a/mips_api/__init__.py
+++ b/mips_api/__init__.py
@@ -157,6 +157,18 @@ def process_chart(chart_dict, omit_list, extra_dict):
 
     return out_chart
 
+def _param_filter_bool(params):
+    return ('filter' in params)
+
+def _param_limit_int(params):
+    if 'limit' in params:
+        try:
+            return int(params['limit'])
+        except TypeError as exc:
+            err_str = "QueryStringParameter 'limit' must be an Integer"
+            raise TypeError(err_str) from exc
+    return 0
+
 def filter_chart(params, raw_chart, omit_list, extra_dict):
     '''
     Optionally process the chart of accounts based on a query-string parameter."
@@ -165,17 +177,11 @@ def filter_chart(params, raw_chart, omit_list, extra_dict):
     mips_dict = raw_chart
 
     # if a 'filter' query-string parameter is defined, process the chart
-    if params and 'filter' in params:
+    if _param_filter_bool(params):
         mips_dict = process_chart(raw_chart, omit_list, extra_dict)
 
     # if a 'limit' query-string parameter is defined, "slice" the dictionary
-    limit = 0
-    if params and 'limit' in params:
-        try:
-            limit = int(params['limit'])
-        except TypeError as exc:
-            err_str = "QueryStringParameter 'limit' must be an Integer"
-            raise TypeError(err_str)
+    limit = _param_limit_int(params)
     if limit > 0:
         # https://stackoverflow.com/a/66535220/1742875
         _mips_dict = dict(list(mips_dict.items())[:limit])
@@ -200,15 +206,7 @@ def list_tags(params, chart_dict):
         tag = f"{name} / {code}"
         tags.append(tag)
 
-    limit = 0
-    if params:
-        if 'limit' in params:
-            try:
-                limit = int(params['limit'])
-            except TypeError as exc:
-                err_str = "QueryStringParameter 'limit' must be an Integer"
-                raise TypeError(err_str)
-
+    limit = _param_limit_int(params)
     if limit > 0:
         LOG.info(f"limiting output to {limit} values")
         return tags[0:limit]

--- a/mips_api/__init__.py
+++ b/mips_api/__init__.py
@@ -125,7 +125,52 @@ def collect_chart(org_name, secrets):
     return mips_dict
 
 
-def list_tags(params, chart_dict, omit_list, extra_dict):
+def process_chart(chart_dict, omit_list, extra_dict):
+    '''
+    Process chart of accounts to remove unneeded programs,
+    and inject some extra (meta) programs.
+
+    5-digit codes are inactive and should be ignored.
+    8-digit codes are active, but only the first 6 digits are significant,
+    i.e. 12345601 and 12345602 should be deduplicated as 123456.
+    '''
+
+    # deduplicate on shortened numeric codes
+    # pre-populate with codes to omit to short-circuit their processing
+    found_codes = []
+    found_codes.extend(omit_list)
+
+    # output object
+    out_chart = {}
+
+    # inject our extra programs at the beginning
+    for code, name in extra_dict.items():
+        out_chart[code] = name
+
+    # add active short codes
+    for code, name in chart_dict.items():
+        if len(code) > 5: # only include active codes
+            short = code[:6]  # ignore the last two digits on active codes
+            if short not in found_codes:
+                out_chart[short] = name
+                found_codes.append(short)
+
+    return out_chart
+
+def filter_chart(params, raw_chart, omit_list, extra_dict):
+    '''
+    Optionally process the chart of accounts based on a query-string parameter."
+    '''
+
+    mips_dict = raw_chart
+
+    # if a 'filter' query-string parameter is defined, process the chart
+    if params and 'filter' in params:
+        mips_dict = process_chart(raw_chart, omit_list, extra_dict)
+
+    return mips_dict
+
+def list_tags(params, chart_dict):
     '''
     Generate a list of valid AWS tags. Only active codes are listed.
 
@@ -136,22 +181,11 @@ def list_tags(params, chart_dict, omit_list, extra_dict):
     '''
 
     tags = []
-    found_codes = []
 
-    # inject extra cost centers
-    for code, name in extra_dict.items():
-        tags.append(f"{name} / {code}")
-
-    # inactive codes have 5 digits, active codes have 8;
-    # and only the first 6 digits of active codes are significant
+    # build tags from chart of accounts
     for code, name in chart_dict.items():
-        if len(code) > 5: # only include active codes
-            short = code[:6]  # ignore the last two digits on active codes
-            if short not in omit_list:
-                if short not in found_codes:
-                    tag = f"{name} / {short}"
-                    tags.append(tag)
-                    found_codes.append(short)
+        tag = f"{name} / {code}"
+        tags.append(tag)
 
     limit = 0
     if params:
@@ -217,7 +251,7 @@ def lambda_handler(event, context):
         ssm_secrets = collect_secrets(ssm_path)
 
         # get chart of accounts from mips
-        mips_chart = collect_chart(mips_org, ssm_secrets)
+        raw_chart = collect_chart(mips_org, ssm_secrets)
 
         # collect query-string parameters
         params = {}
@@ -229,14 +263,14 @@ def lambda_handler(event, context):
             event_path = event['path']
 
             if event_path == api_routes['ApiChartOfAccounts']:
-                # return chart of accounts
+                # return chart of accounts, optionally processed
+                mips_chart = filter_chart(params, raw_chart, omit_codes_list, extra_codes_dict)
                 return _build_return(200, mips_chart)
 
             elif event_path == api_routes['ApiValidTags']:
-                try:
-                    valid_tags = list_tags(params, mips_chart, omit_codes_list, extra_codes_dict)
-                except Exception as exc:
-                    return _build_return(500, {"error": str(exc)})
+                # always process the chart for the tags list
+                mips_chart = process_chart(raw_chart, omit_codes_list, extra_codes_dict)
+                valid_tags = list_tags(params, mips_chart)
 
                 # return valid tags
                 return _build_return(200, valid_tags)

--- a/mips_api/__init__.py
+++ b/mips_api/__init__.py
@@ -168,6 +168,19 @@ def filter_chart(params, raw_chart, omit_list, extra_dict):
     if params and 'filter' in params:
         mips_dict = process_chart(raw_chart, omit_list, extra_dict)
 
+    # if a 'limit' query-string parameter is defined, "slice" the dictionary
+    limit = 0
+    if params and 'limit' in params:
+        try:
+            limit = int(params['limit'])
+        except TypeError as exc:
+            err_str = "QueryStringParameter 'limit' must be an Integer"
+            raise TypeError(err_str)
+    if limit > 0:
+        # https://stackoverflow.com/a/66535220/1742875
+        _mips_dict = dict(list(mips_dict.items())[:limit])
+        return _mips_dict
+
     return mips_dict
 
 def list_tags(params, chart_dict):

--- a/mips_api/__init__.py
+++ b/mips_api/__init__.py
@@ -158,7 +158,7 @@ def process_chart(chart_dict, omit_list, extra_dict):
     return out_chart
 
 def _param_filter_bool(params):
-    return ('filter' in params)
+    return ('filter' in params) and params['filter']
 
 def _param_limit_int(params):
     if 'limit' in params:

--- a/mips_api/__init__.py
+++ b/mips_api/__init__.py
@@ -158,8 +158,8 @@ def process_chart(chart_dict, omit_list, extra_dict):
     return out_chart
 
 def _param_filter_bool(params):
-    if 'filter' in params:
-        if params['filter'].lower() not in [ 'false', 'no', 'off' ]:
+    if 'enable_code_filter' in params:
+        if params['enable_code_filter'].lower() not in [ 'false', 'no', 'off' ]:
             return True
     return False
 
@@ -179,7 +179,7 @@ def filter_chart(params, raw_chart, omit_list, extra_dict):
 
     mips_dict = raw_chart
 
-    # if a 'filter' query-string parameter is defined, process the chart
+    # if an 'enable_code_filter' query-string parameter is defined, process the chart
     if _param_filter_bool(params):
         mips_dict = process_chart(raw_chart, omit_list, extra_dict)
 

--- a/mips_api/__init__.py
+++ b/mips_api/__init__.py
@@ -281,4 +281,5 @@ def lambda_handler(event, context):
         return _build_return(400, {"error": f"Invalid event: No path found: {event}"})
 
     except Exception as exc:
+        LOG.exception(exc)
         return _build_return(500, {"error": str(exc)})

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -96,7 +96,7 @@ expected_mips_dict_raw = {
     '99990000': 'Unfunded',
 }
 
-expected_mips_dict_raw_limit_3 = {
+expected_mips_dict_raw_limit = {
     '12345600': 'Other Program A',
     '12345601': 'Other Program B',
     '54321': 'Inactive',
@@ -109,7 +109,7 @@ expected_mips_dict_processed = {
     '990300': 'Platform Infrastructure',
 }
 
-expected_mips_dict_processed_limit_3 = {
+expected_mips_dict_processed_limit = {
     '000000': 'No Program',
     '000001': 'Other',
     '123456': 'Other Program A',
@@ -123,9 +123,18 @@ expected_tag_list = [
     'Platform Infrastructure / 990300',
 ]
 
+# expected tag list
+expected_tag_list_limit = [
+    'No Program / 000000',
+    'Other / 000001',
+    'Other Program A / 123456',
+]
+
 # mock query-string parameters
-mock_limit_param = { 'limit': 3 }
+mock_foo_param = { 'foo': 'bar' }
+mock_limit_param = { 'limit': '3' }
 mock_filter_param = { 'filter': 'true' }
+mock_filter_and_limit_param = { 'filter': '', 'limit': '3' }
 
 # expected tag list with limit
 expected_tag_limit_list = expected_tag_list[0:3]
@@ -348,10 +357,10 @@ def test_param_limit_int_err(params):
         "params,expected_dict",
         [
             ({}, expected_mips_dict_raw),
-            ({'foo': 'bar'}, expected_mips_dict_raw),
-            ({'limit': '3'}, expected_mips_dict_raw_limit_3),
-            ({'filter': 'true'}, expected_mips_dict_processed),
-            ({'filter': '', 'limit': '3'}, expected_mips_dict_processed_limit_3),
+            (mock_foo_param, expected_mips_dict_raw),
+            (mock_limit_param, expected_mips_dict_raw_limit),
+            (mock_filter_param, expected_mips_dict_processed),
+            (mock_filter_and_limit_param, expected_mips_dict_processed_limit),
         ]
     )
 def test_filter_chart(params, expected_dict):
@@ -359,20 +368,20 @@ def test_filter_chart(params, expected_dict):
     assert processed_chart == expected_dict
 
 
-def test_tags():
+@pytest.mark.parametrize(
+        "params,expected_list",
+        [
+            ({}, expected_tag_list),
+            (mock_foo_param, expected_tag_list),
+            (mock_limit_param, expected_tag_list_limit),
+        ]
+    )
+def test_tags(params, expected_list):
     '''Testing building tag list from collected chart of accounts'''
 
     # assert expected tag list
-    tag_list = mips_api.list_tags({}, expected_mips_dict_processed)
-    assert tag_list == expected_tag_list
-
-
-def test_tags_limit():
-    '''Testing building tag list from collected chart of accounts'''
-
-    # assert expected tag list
-    tag_list = mips_api.list_tags(mock_limit_param, expected_mips_dict_processed)
-    assert tag_list == expected_tag_limit_list
+    tag_list = mips_api.list_tags(params, expected_mips_dict_processed)
+    assert tag_list == expected_list
 
 
 def test_lambda_handler_no_env(invalid_event):

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -133,8 +133,8 @@ expected_tag_list_limit = [
 # mock query-string parameters
 mock_foo_param = { 'foo': 'bar' }
 mock_limit_param = { 'limit': '3' }
-mock_filter_param = { 'filter': 'true' }
-mock_filter_and_limit_param = { 'filter': '', 'limit': '3' }
+mock_filter_param = { 'enable_code_filter': 'true' }
+mock_filter_and_limit_param = { 'enable_code_filter': '', 'limit': '3' }
 
 # expected tag list with limit
 expected_tag_limit_list = expected_tag_list[0:3]
@@ -316,11 +316,11 @@ def test_process_chart():
         [
             ({}, False),
             ({'foo': 'bar'}, False),
-            ({'filter': 'false'}, False),
-            ({'filter': 'OFF'}, False),
-            ({'filter': 'True'}, True),
-            ({'filter': 'oN'}, True),
-            ({'filter': ''}, True),
+            ({'enable_code_filter': 'false'}, False),
+            ({'enable_code_filter': 'OFF'}, False),
+            ({'enable_code_filter': 'True'}, True),
+            ({'enable_code_filter': 'oN'}, True),
+            ({'enable_code_filter': ''}, True),
         ]
     )
 def test_param_filter_bool(params, expected_bool):

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -292,7 +292,7 @@ def test_tags():
     '''Testing building tag list from collected chart of accounts'''
 
     # assert expected tag list
-    tag_list = mips_api.list_tags(None, expected_mips_dict_processed)
+    tag_list = mips_api.list_tags({}, expected_mips_dict_processed)
     assert tag_list == expected_tag_list
 
 


### PR DESCRIPTION
lambda-finops-cost-rules expects a chart-of-accounts dictionary processed with omit/extra codes and for code deduplication, add a query-string parameter to toggle this behavior.