### PR TITLE
[IT-1655] Remove Other from default CodesToAdd

### DIFF
--- a/mips_api/__init__.py
+++ b/mips_api/__init__.py
@@ -27,14 +27,19 @@ def _get_os_var(varnam):
 
 
 def _parse_omit_codes(omit_codes):
-    return omit_codes.split(',')
+    data = []
+    if omit_codes:
+        data = omit_codes.split(',')
+    return data
 
 
 def _parse_extra_codes(extra_codes):
     data = {}
-    for _kv_pair in extra_codes.split(','):
-        k, v = _kv_pair.split(':', 1)
-        data[k] = v
+    if extra_codes:
+        for _kv_pair in extra_codes.split(','):
+            if _kv_pair and ':' in _kv_pair:
+                k, v = _kv_pair.split(':', 1)
+                data[k] = v
     return data
 
 def collect_secrets(ssm_path):

--- a/template.yaml
+++ b/template.yaml
@@ -42,7 +42,7 @@ Parameters:
   CodesToAdd:
     Type: String
     Description: Comma-delimited list of code:name pairs to add to the active list.
-    Default: '000000:No Program,000001:Other'
+    Default: '000000:No Program'
 
 
 Conditions:

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -296,14 +296,36 @@ def test_chart(requests_mock):
     assert logout_mock.call_count == 2
 
 
-def test_parse_omit():
-    parsed_omit_codes = mips_api._parse_omit_codes(omit_codes)
-    assert parsed_omit_codes == expected_omit_codes
+@pytest.mark.parametrize(
+        "code_str,code_list",
+        [
+            (None, []),
+            ('', []),
+            ('1', ['1']),
+            ('1,2', ['1', '2']),
+            (omit_codes, expected_omit_codes),
+        ]
+    )
+def test_parse_omit(code_str, code_list):
+    parsed_omit_codes = mips_api._parse_omit_codes(code_str)
+    assert parsed_omit_codes == code_list
 
 
-def test_parse_extra():
-    parsed_extra_codes = mips_api._parse_extra_codes(extra_codes)
-    assert parsed_extra_codes == expected_extra_codes
+@pytest.mark.parametrize(
+        "code_str,code_dict",
+        [
+            (None, {}),
+            ('', {}),
+            ('123', {}),
+            ('123,abc', {}),
+            ('123:abc', {'123': 'abc'}),
+            ('123:abc:def', {'123': 'abc:def'}),
+            (extra_codes, expected_extra_codes),
+        ]
+    )
+def test_parse_extra(code_str, code_dict):
+    parsed_extra_codes = mips_api._parse_extra_codes(code_str)
+    assert parsed_extra_codes == code_dict
 
 
 def test_process_chart():


### PR DESCRIPTION
Parameterize env-var parsing tests, and improve parsing error handling
