### PR TITLE
Treat 'Other' and 'No Program' codes differently

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,17 @@ The following template parameters are set as environment variables in the lambda
 A couple query-string parameters are available to configure response output.
 
 An `enable_code_filter` parameter is available for the `/accounts` endpoint to
-optionally remove inactive codes and `CodesToOmit`, as well as inject a
-"No Program" code with a value from the `NoProgramCode` parameter.
+optionally remove inactive codes and `CodesToOmit`.
 Defining any non-false value for this parameter will enable it.
 
 An `enable_other_code` parameter is available for either endpoint to optionally
 include an "Other" entry in the output with a value from the `OtherCode`
 parameter. Defining any non-false value for this parameter will enable it.
+
+A `disable_no_program_code` parameter is available for either endpoint to optionally
+exclude a "No Program" entry from the output, otherwise it will be injected
+with a value from the `NoProgramCode` parameter.
+Defining any non-false value for this parameter will enable it.
 
 A `limit` parameter is available for either endpoint to restrict the number of
 items returned. This value must be a positive integer, a value of zero
@@ -70,6 +74,7 @@ disables the parameter.
 | --- | --- | --- |
 | enable\_code\_filter | /accounts | Undefined (disabled) |
 | enable\_other\_code | /accounts /tags | Undefined (disabled) |
+| disable\_no\_program\_code | /accounts /tags | Undefined (disabled) |
 | limit | /accounts /tags | `0` (disabled) |
 
 ### Triggering

--- a/README.md
+++ b/README.md
@@ -46,15 +46,21 @@ The following template parameters are set as environment variables in the lambda
 | MipsOrganization | MipsOrg | Log in to this organization in the finance system. |
 | SsmParamPrefix | SsmPath | Path prefix for required secure parameters. |
 | CodesToOmit | CodesToOmit | List of numeric codes to treat as inactive. |
-| CodesToAdd | CodesToAdd | List of "code:name" strings to add to the active list. |
+| NoProgramCode | NoProgramCode | Numeric code to use for "No Program" meta-program. |
+| OtherCode | OtherCode | Numeric code to use for "Other" meta-program. |
 
 ### Query String Parameters
 
 A couple query-string parameters are available to configure response output.
 
-An `enable_code_filter` parameter is available for the `/accounts` endpoint to optionally
-process the chart of accounts based on the values of `CodesToOmit` and `CodesToAdd`.
+An `enable_code_filter` parameter is available for the `/accounts` endpoint to
+optionally remove inactive codes and `CodesToOmit`, as well as inject a
+"No Program" code with a value from the `NoProgramCode` parameter.
 Defining any non-false value for this parameter will enable it.
+
+An `enable_other_code` parameter is available for either endpoint to optionally
+include an "Other" entry in the output with a value from the `OtherCode`
+parameter. Defining any non-false value for this parameter will enable it.
 
 A `limit` parameter is available for either endpoint to restrict the number of
 items returned. This value must be a positive integer, a value of zero
@@ -63,6 +69,7 @@ disables the parameter.
 | Query String Parameter | Valid Routes | Default Value |
 | --- | --- | --- |
 | enable\_code\_filter | /accounts | Undefined (disabled) |
+| enable\_other\_code | /accounts /tags | Undefined (disabled) |
 | limit | /accounts /tags | `0` (disabled) |
 
 ### Triggering

--- a/mips_api/__init__.py
+++ b/mips_api/__init__.py
@@ -48,6 +48,10 @@ def _param_other_bool(params):
     return _param_bool(params, 'enable_other_code')
 
 
+def _param_no_program_bool(params):
+    return not _param_bool(params, 'disable_no_program_code')
+
+
 def _param_limit_int(params):
     if params and 'limit' in params:
         try:
@@ -164,10 +168,11 @@ def process_chart(params, chart_dict, omit_list, other, no_program):
     # output object
     out_chart = {}
 
-    # always inject "no program" code
-    out_chart[no_program] = "No Program"
+    # inject "no program" code
+    if _param_no_program_bool(params):
+        out_chart[no_program] = "No Program"
 
-    # optionally inject "other" code
+    # inject "other" code
     if _param_other_bool(params):
         out_chart[other] = "Other"
 

--- a/template.yaml
+++ b/template.yaml
@@ -43,6 +43,14 @@ Parameters:
     Type: String
     Description: Comma-delimited list of code:name pairs to add to the active list.
     Default: '000000:No Program'
+  NoProgramCode:
+    Type: String
+    Description: Numeric code for the "No Program" meta-program
+    Default: '000000'
+  OtherCode:
+    Type: String
+    Description: Numeric code for the "Other" meta-program
+    Default: '000001'
 
 
 Conditions:
@@ -66,6 +74,8 @@ Resources:
           SsmPath: !Ref SsmParamPrefix
           CodesToOmit: !Ref CodesToOmit
           CodesToAdd: !Ref CodesToAdd
+          NoProgramCode: !Ref NoProgramCode
+          OtherCode: !Ref OtherCode
       Role: !GetAtt FunctionRole.Arn
       Events:
         ChartOfAccounts:

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -110,6 +110,17 @@ expected_mips_dict_processed_other = {
     '990300': 'Platform Infrastructure',
 }
 
+expected_mips_dict_processed_no = {
+    '123456': 'Other Program A',
+    '990300': 'Platform Infrastructure',
+}
+
+expected_mips_dict_processed_other_no = {
+    '000001': 'Other',
+    '123456': 'Other Program A',
+    '990300': 'Platform Infrastructure',
+}
+
 expected_mips_dict_processed_limit = {
     '000000': 'No Program',
     '123456': 'Other Program A',
@@ -133,7 +144,7 @@ mock_foo_param = { 'foo': 'bar' }
 mock_limit_param = { 'limit': '2' }
 mock_other_param = { 'enable_other_code': 'true' }
 mock_filter_param = { 'enable_code_filter': 'true' }
-mock_filter_and_limit_param = { 'enable_code_filter': '', 'limit': '2' }
+mock_no_program_param = { 'disable_no_program_code': 'true' }
 
 
 def apigw_event(path, qsp={"foo": "bar"}):
@@ -313,6 +324,8 @@ def test_parse_omit(code_str, code_list):
             ({}, expected_mips_dict_processed),
             (mock_foo_param, expected_mips_dict_processed),
             (mock_other_param, expected_mips_dict_processed_other),
+            (mock_no_program_param, expected_mips_dict_processed_no),
+            (mock_other_param | mock_no_program_param, expected_mips_dict_processed_other_no),
         ]
     )
 def test_process_chart(params, expected_dict):
@@ -326,15 +339,15 @@ def test_process_chart(params, expected_dict):
             ({}, False),
             (None, False),
             ({'foo': 'bar'}, False),
-            ({'enable_code_filter': 'false'}, False),
-            ({'enable_code_filter': 'OFF'}, False),
-            ({'enable_code_filter': 'True'}, True),
-            ({'enable_code_filter': 'oN'}, True),
-            ({'enable_code_filter': ''}, True),
+            ({'test': 'false'}, False),
+            ({'test': 'OFF'}, False),
+            ({'test': 'True'}, True),
+            ({'test': 'oN'}, True),
+            ({'test': ''}, True),
         ]
     )
-def test_param_filter_bool(params, expected_bool):
-    found_filter_bool = mips_api._param_filter_bool(params)
+def test_param_bool(params, expected_bool):
+    found_filter_bool = mips_api._param_bool(params, 'test')
     assert found_filter_bool == expected_bool
 
 
@@ -371,7 +384,7 @@ def test_param_limit_int_err(params):
             (mock_foo_param, expected_mips_dict_raw),
             (mock_limit_param, expected_mips_dict_raw_limit),
             (mock_filter_param, expected_mips_dict_processed),
-            (mock_filter_and_limit_param, expected_mips_dict_processed_limit),
+            (mock_limit_param | mock_filter_param, expected_mips_dict_processed_limit),
         ]
     )
 def test_filter_chart(params, expected_dict):


### PR DESCRIPTION
In order to only provide an 'Other' meta-code to Service Catalog while always adding a 'No Program' meta-code, configure the codes with different template parameters, and add a query-string parameter for including the 'Other' code.

