### PR TITLE
[IT-2796] Correct login url

### DIFF
--- a/mips_api/__init__.py
+++ b/mips_api/__init__.py
@@ -9,7 +9,7 @@ import requests
 LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.INFO)
 
-_mips_url_login = 'https://portal.mip.com/api/v1/sso/mipadv/login'
+_mips_url_login = 'https://login.mip.com/api/v1/sso/mipadv/login'
 _mips_url_chart = 'https://api.mip.com/api/v1/maintain/chartofaccounts'
 _mips_url_logout = 'https://api.mip.com/api/security/logout'
 


### PR DESCRIPTION
A MIP support tech has informed me that the login call should be made to login.mip.com (this url wasn't mentioned in the migration email).
