### PR TITLE
[IT-2984] Optionally keep inactive codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,13 @@ The following template parameters are set as environment variables in the lambda
 A couple query-string parameters are available to configure response output.
 
 An `enable_code_filter` parameter is available for the `/accounts` endpoint to
-optionally remove inactive codes and `CodesToOmit`.
+optionally deduplicate codes, removing inactive codes and `CodesToOmit`.
 Defining any non-false value for this parameter will enable it.
+
+A `disable_inactive_filter` parameter is available to modify the behavior of
+`enable_code_filter`. If this parameter is set to any non-false value, inactive
+codes are no longer removed. Codes are still deduplicated and `CodesToOmit` is
+respected. This parameter has no effect if `enable_code_filter` is not enabled.
 
 An `enable_other_code` parameter is available for either endpoint to optionally
 include an "Other" entry in the output with a value from the `OtherCode`

--- a/mips_api/__init__.py
+++ b/mips_api/__init__.py
@@ -44,6 +44,10 @@ def _param_filter_bool(params):
     return _param_bool(params, 'enable_code_filter')
 
 
+def _param_inactive_bool(params):
+    return not _param_bool(params, 'disable_inactive_filter')
+
+
 def _param_other_bool(params):
     return _param_bool(params, 'enable_other_code')
 
@@ -176,9 +180,16 @@ def process_chart(params, chart_dict, omit_list, other, no_program):
     if _param_other_bool(params):
         out_chart[other] = "Other"
 
-    # add active short codes
+    # whether or not to filter out inactive codes
+    _skip_inactive = _param_inactive_bool(params)
+
+    # add short codes
     for code, name in chart_dict.items():
-        if len(code) > 5: # only include active codes
+        code_len = 5
+        if _skip_inactive:
+            code_len = 6
+
+        if len(code) >= code_len:
             short = code[:6]  # ignore the last two digits on active codes
             if short not in found_codes:
                 out_chart[short] = name

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -121,6 +121,13 @@ expected_mips_dict_processed_other_no = {
     '990300': 'Platform Infrastructure',
 }
 
+expected_mips_dict_processed_inactive = {
+    '000000': 'No Program',
+    '123456': 'Other Program A',
+    '54321': 'Inactive',
+    '990300': 'Platform Infrastructure',
+}
+
 expected_mips_dict_processed_limit = {
     '000000': 'No Program',
     '123456': 'Other Program A',
@@ -144,6 +151,7 @@ mock_foo_param = { 'foo': 'bar' }
 mock_limit_param = { 'limit': '2' }
 mock_other_param = { 'enable_other_code': 'true' }
 mock_filter_param = { 'enable_code_filter': 'true' }
+mock_inactive_param = { 'disable_inactive_filter': 'true' }
 mock_no_program_param = { 'disable_no_program_code': 'true' }
 
 
@@ -324,6 +332,7 @@ def test_parse_omit(code_str, code_list):
             ({}, expected_mips_dict_processed),
             (mock_foo_param, expected_mips_dict_processed),
             (mock_other_param, expected_mips_dict_processed_other),
+            (mock_inactive_param, expected_mips_dict_processed_inactive),
             (mock_no_program_param, expected_mips_dict_processed_no),
             (mock_other_param | mock_no_program_param, expected_mips_dict_processed_other_no),
         ]


### PR DESCRIPTION
Add a query-string parameter to disable the filtering of inactive codes while still deduplicating codes so that we can build cost category rules for inactive programs.
