### PR TITLE
[IT-3021] Add 'priority-codes' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,19 @@ An AWS Lambda microservice presenting MIPS chart of accounts data
 
 ## Architecture
 
-This microservice is designed to retrieve a chart of accounts from a third-party API and present the data in a useful format.
+This microservice is designed to retrieve a chart of accounts from a third-party
+API and present the data in a useful format.
 
 Formats available:
-| Route | Description |
-| --- | --- |
-| /accounts | A dictionary mapping all active and inactive accounts to their friendly names (for debugging). |
-| /tags | A list of valid tag values for either `CostCenter` or `CostCenterOther`. |
 
-Since we reach out to a third-party API across the internet, responses are cached to minimize interaction with the API
-and mitigate potential environmental issues (e.g. packet loss).
+| Route     | Description                                                              |
+| --------- |--------------------------------------------------------------------------|
+| /accounts | A dictionary mapping the chart of accounts to their friendly names.      |
+| /tags     | A list of valid tag values for either `CostCenter` or `CostCenterOther`. |
+
+Since we reach out to a third-party API across the internet, responses are
+cached to minimize interaction with the API and mitigate potential
+environmental issues (e.g. packet loss).
 
 ![Component Diagram](docs/lambda-mips-api_components.drawio.png)
 
@@ -21,6 +24,15 @@ which will read login credentials from secure parameters in SSM, query MIPS for 
 and return a JSON mapping of the data to be stored in Cloudfront for a default of one day.
 
 In the event of a cache hit, Cloudfront will return the cached value without triggering an API gateway event.
+
+### Default Behavior
+
+By default, the lambda will process the chart of accounts received to remove
+inactive codes, deduplicate the significant portion of active codes, and add
+a "No Program" entry mapped to a code configured in a template parameter. Each
+of these actions can be toggled with query-string parameters, except for
+deduplication. Specific account codes from the chart of accounts can be ignored
+globally with the `CodesToOmit`template parameter.
 
 ### Required Secure Parameters
 
@@ -33,54 +45,55 @@ By default, the prefix is `/lambda/mipsSecret`, resulting the following required
 
 The following template parameters are used to configure CloudFormation resources
 
-| Template Parameter | Description |
-| --- | --- |
-| SsmAliasPrefix | Prepend this value to the Alias Name of the KMS key created. |
-| SsmKeyAdminArn | Grant KMS admin access to these ARNs for managing secure secrets. |
+| Template Parameter | Description                                                       |
+|--------------------|-------------------------------------------------------------------|
+| CacheTTL           | TTL value for CloudFront cache objects.                           |
+| SsmAliasPrefix     | Prepend this value to the Alias Name of the KMS key created.      |
+| SsmKeyAdminArn     | Grant KMS admin access to these ARNs for managing secure secrets. |
 
 The following template parameters are set as environment variables in the lambda environment:
 
-| Template Parameter | Environment Variable | Description |
-| --- | --- | --- |
-| CacheTTL | CacheTTL | TTL value for CloudFront cache objects. |
-| MipsOrganization | MipsOrg | Log in to this organization in the finance system. |
-| SsmParamPrefix | SsmPath | Path prefix for required secure parameters. |
-| CodesToOmit | CodesToOmit | List of numeric codes to treat as inactive. |
-| NoProgramCode | NoProgramCode | Numeric code to use for "No Program" meta-program. |
-| OtherCode | OtherCode | Numeric code to use for "Other" meta-program. |
+| Template Parameter | Environment Variable | Description                                        |
+| ------------------ | -------------------- |----------------------------------------------------|
+| MipsOrganization   | MipsOrg              | Log in to this organization in the finance system. |
+| SsmParamPrefix     | SsmPath              | Path prefix for required secure parameters.        |
+| CodesToOmit        | CodesToOmit          | List of numeric codes to remove from output.       |
+| NoProgramCode      | NoProgramCode        | Numeric code to use for "No Program" entry.        |
+| OtherCode          | OtherCode            | Numeric code to use for "Other" entry.             |
 
 ### Query String Parameters
 
-A couple query-string parameters are available to configure response output.
+Several query-string parameters are available for either endpoint to configure
+response output.
 
-An `enable_code_filter` parameter is available for the `/accounts` endpoint to
-optionally deduplicate codes, removing inactive codes and `CodesToOmit`.
-Defining any non-false value for this parameter will enable it.
+| Query String Parameter | Allowed Values                        |
+|------------------------|---------------------------------------|
+| show_other_code        | "on" or "yes" or "true"               |
+| hide_no_program_code   | "on" or "yes" or "true"               |
+| show_inactive_codes    | "on" or "yes" or "true"               |
+| priority_codes         | Comma-separated list of numeric codes |
+| limit                  | Integer                               |
 
-A `disable_inactive_filter` parameter is available to modify the behavior of
-`enable_code_filter`. If this parameter is set to any non-false value, inactive
-codes are no longer removed. Codes are still deduplicated and `CodesToOmit` is
-respected. This parameter has no effect if `enable_code_filter` is not enabled.
+A `show_other_code` parameter is available to optionally include an "Other"
+entry in the output with a value from the `OtherCode` parameter. Defining any
+non-false value for this parameter will include the code.
 
-An `enable_other_code` parameter is available for either endpoint to optionally
-include an "Other" entry in the output with a value from the `OtherCode`
-parameter. Defining any non-false value for this parameter will enable it.
+A `hide_no_program_code` parameter is available to prevent the default addition
+of a "No Program" entry, otherwise it will be added with the value from the
+`NoProgramCode` parameter. Defining any non-false value for this parameter will
+prevent the addition of a "No Program" entry.
 
-A `disable_no_program_code` parameter is available for either endpoint to optionally
-exclude a "No Program" entry from the output, otherwise it will be injected
-with a value from the `NoProgramCode` parameter.
-Defining any non-false value for this parameter will enable it.
+A `show_inactive_codes` parameter is available to prevent the default removal of
+inactive codes. If this parameter is set to any non-false value, inactive codes
+will be included in the output.
 
-A `limit` parameter is available for either endpoint to restrict the number of
-items returned. This value must be a positive integer, a value of zero
-disables the parameter.
+A `priority_codes` parameter is available to prioritize specified entries
+from the chart of accounts to the top of the output; `OtherCode` and
+`NoProgramCode` are always prioritized when included.
+Example value: `"123456,654321"`.
 
-| Query String Parameter | Valid Routes | Default Value |
-| --- | --- | --- |
-| enable\_code\_filter | /accounts | Undefined (disabled) |
-| enable\_other\_code | /accounts /tags | Undefined (disabled) |
-| disable\_no\_program\_code | /accounts /tags | Undefined (disabled) |
-| limit | /accounts /tags | `0` (disabled) |
+A `limit` parameter is available to restrict the number of items returned. This
+value must be a positive integer, a value of zero disables the parameter.
 
 ### Triggering
 
@@ -94,45 +107,38 @@ These URLs can be also constructed by appending the API Gateway paths to the Clo
 
 The CloudFormation template also outputs the origin URL behind the CloudFront distribution for debugging purposes.
 
-### Respones Formats
+### Response Formats
 
 #### /accounts
 
-The `/accounts` endpoint will return a json string representing a dictionary mapping numeric codes to their names.
-By default, this dictionary represents the raw chart of accounts provided by the upstream API, without any filtering or
-deduplication of codes; but this can be toggled by defining an 'enable\_code\_filter' query-string parameter.
+The `/accounts` endpoint will return a json string representing a dictionary
+mapping numeric account codes to their friendly names.
 
 E.g.:
 
-`/accounts`
-```json
-{
-  "12345600": "Duplicate 1",
-  "12345699": "Duplicate 2",
-  "54321": "Inactive",
-  "99030000": "Platform Infrastructure"
-}
-```
-
-`/accounts?enable_code_filter`
+`/accounts?show_inactive_codes=on`
 ```json
 {
   "000000": "No Program",
   "123456": "Duplicate 1",
+  "54321": "Inactive",
   "990300": "Platform Infrastructure"
 }
 ```
 
 #### /tags
 
-The `/tags` endpointwill return a json string representing a list of valid values for CostCenter tags.
-A valid CostCenter tag value takes the form '{Friendly Name} / {Numeric Code}'.
-Values are only generated for currently-active program codes.
+The `/tags` endpoint will return a json string representing a list of valid
+values for CostCenter tags. A valid CostCenter tag value takes the form
+'{Friendly Name} / {Numeric Code}'.
 
 E.g.:
+
+`/tags?show_other_code=on`
 ```json
 [
   "No Program / 000000",
+  "Other / 000001",
   "Duplicate 1 / 123456",
   "Platform Infrastructure / 990300"
 ]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ API and present the data in a useful format.
 
 Formats available:
 
-| Route     | Description                                                              |
-| --------- |--------------------------------------------------------------------------|
+| API Route | Description                                                              |
+|-----------|--------------------------------------------------------------------------|
 | /accounts | A dictionary mapping the chart of accounts to their friendly names.      |
 | /tags     | A list of valid tag values for either `CostCenter` or `CostCenterOther`. |
 
@@ -31,8 +31,12 @@ By default, the lambda will process the chart of accounts received to remove
 inactive codes, deduplicate the significant portion of active codes, and add
 a "No Program" entry mapped to a code configured in a template parameter. Each
 of these actions can be toggled with query-string parameters, except for
-deduplication. Specific account codes from the chart of accounts can be ignored
-globally with the `CodesToOmit`template parameter.
+deduplication.
+
+Specific account codes from the chart of accounts can be ignored globally with
+the `CodesToOmit` template parameter. Remaining codes will be returned in
+numeric order as either a list of strings or a json dictionary depending on the
+API route.
 
 ### Required Secure Parameters
 
@@ -87,10 +91,10 @@ A `show_inactive_codes` parameter is available to prevent the default removal of
 inactive codes. If this parameter is set to any non-false value, inactive codes
 will be included in the output.
 
-A `priority_codes` parameter is available to prioritize specified entries
-from the chart of accounts to the top of the output; `OtherCode` and
-`NoProgramCode` are always prioritized when included.
-Example value: `"123456,654321"`.
+By default, the output is ordered by numeric code. A `priority_codes` parameter
+is available to select specific programs to prioritize to the beginning of the
+output regardless of their code; `OtherCode` and`NoProgramCode` are always
+prioritized when included. Example value: `123456,654321`.
 
 A `limit` parameter is available to restrict the number of items returned. This
 value must be a positive integer, a value of zero disables the parameter.

--- a/template.yaml
+++ b/template.yaml
@@ -39,10 +39,6 @@ Parameters:
     Type: String
     Description: Comma-delimited list of numeric codes to ignore (treat as inactive).
     Default: '999900,999800,999700,990500'
-  CodesToAdd:
-    Type: String
-    Description: Comma-delimited list of code:name pairs to add to the active list.
-    Default: '000000:No Program'
   NoProgramCode:
     Type: String
     Description: Numeric code for the "No Program" meta-program
@@ -69,11 +65,9 @@ Resources:
         Variables:
           ApiChartOfAccounts: '/accounts'
           ApiValidTags: '/tags'
-          CacheTTL: !Ref CacheTTL
           MipsOrg: !Ref MipsOrganization
           SsmPath: !Ref SsmParamPrefix
           CodesToOmit: !Ref CodesToOmit
-          CodesToAdd: !Ref CodesToAdd
           NoProgramCode: !Ref NoProgramCode
           OtherCode: !Ref OtherCode
       Role: !GetAtt FunctionRole.Arn

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -62,11 +62,15 @@ mock_chart = {
     'data': [
         {
             'accountCodeId': '12345600',
-            'accountTitle': 'Other Program A',
+            'accountTitle': 'Program Part A',
         },
         {
             'accountCodeId': '12345601',
-            'accountTitle': 'Other Program B',
+            'accountTitle': 'Program Part B',
+        },
+        {
+            'accountCodeId': '23456700',
+            'accountTitle': 'Other Program',
         },
         {
             'accountCodeId': '54321',
@@ -85,74 +89,88 @@ mock_chart = {
 
 # expected internal dictionary
 expected_mips_dict_raw = {
-    '12345600': 'Other Program A',
-    '12345601': 'Other Program B',
+    '12345600': 'Program Part A',
+    '12345601': 'Program Part B',
+    '23456700': 'Other Program',
     '54321': 'Inactive',
     '99030000': 'Platform Infrastructure',
     '99990000': 'Unfunded',
 }
 
 expected_mips_dict_raw_limit = {
-    '12345600': 'Other Program A',
-    '12345601': 'Other Program B',
+    '12345600': 'Program Part A',
+    '12345601': 'Program Part B',
 }
 
 expected_mips_dict_processed = {
     '000000': 'No Program',
-    '123456': 'Other Program A',
+    '123456': 'Program Part A',
+    '234567': 'Other Program',
     '990300': 'Platform Infrastructure',
 }
 
 expected_mips_dict_processed_other = {
     '000000': 'No Program',
     '000001': 'Other',
-    '123456': 'Other Program A',
+    '123456': 'Program Part A',
+    '234567': 'Other Program',
     '990300': 'Platform Infrastructure',
 }
 
 expected_mips_dict_processed_no = {
-    '123456': 'Other Program A',
+    '123456': 'Program Part A',
+    '234567': 'Other Program',
     '990300': 'Platform Infrastructure',
 }
 
 expected_mips_dict_processed_other_no = {
     '000001': 'Other',
-    '123456': 'Other Program A',
+    '123456': 'Program Part A',
+    '234567': 'Other Program',
     '990300': 'Platform Infrastructure',
 }
 
 expected_mips_dict_processed_inactive = {
     '000000': 'No Program',
-    '123456': 'Other Program A',
+    '123456': 'Program Part A',
+    '234567': 'Other Program',
     '54321': 'Inactive',
     '990300': 'Platform Infrastructure',
 }
 
 expected_mips_dict_processed_limit = {
     '000000': 'No Program',
-    '123456': 'Other Program A',
+    '123456': 'Program Part A',
+}
+
+expected_mips_dict_processed_priority_codes = {
+    '000000': 'No Program',
+    '123456': 'Program Part A',
+    '234567': 'Other Program',
+    '990300': 'Platform Infrastructure',
 }
 
 # expected tag list
 expected_tag_list = [
     'No Program / 000000',
-    'Other Program A / 123456',
+    'Program Part A / 123456',
+    'Other Program / 234567',
     'Platform Infrastructure / 990300',
 ]
 
 # expected tag list
 expected_tag_list_limit = [
     'No Program / 000000',
-    'Other Program A / 123456',
+    'Program Part A / 123456',
 ]
 
 # mock query-string parameters
-mock_foo_param = { 'foo': 'bar' }
-mock_limit_param = { 'limit': '2' }
-mock_other_param = { 'enable_other_code': 'true' }
-mock_filter_param = { 'enable_code_filter': 'true' }
-mock_inactive_param = { 'disable_inactive_filter': 'true' }
-mock_no_program_param = { 'disable_no_program_code': 'true' }
+mock_foo_param = {'foo': 'bar'}
+mock_limit_param = {'limit': '2'}
+mock_other_param = {'show_other_code': 'true'}
+mock_priority_param = {'priority_codes': '234567'}
+mock_inactive_param = {'show_inactive_codes': 'true'}
+mock_no_program_param = {'hide_no_program_code': 'true'}
 
 
 def apigw_event(path, qsp={"foo": "bar"}):
@@ -321,8 +339,8 @@ def test_chart(requests_mock):
             (omit_codes, expected_omit_codes),
         ]
     )
-def test_parse_omit(code_str, code_list):
-    parsed_omit_codes = mips_api._parse_omit_codes(code_str)
+def test_parse_codes(code_str, code_list):
+    parsed_omit_codes = mips_api._parse_codes(code_str)
     assert parsed_omit_codes == code_list
 
 
@@ -334,11 +352,17 @@ def test_parse_omit(code_str, code_list):
             (mock_other_param, expected_mips_dict_processed_other),
             (mock_inactive_param, expected_mips_dict_processed_inactive),
             (mock_no_program_param, expected_mips_dict_processed_no),
-            (mock_other_param | mock_no_program_param, expected_mips_dict_processed_other_no),
+            (mock_priority_param, expected_mips_dict_processed_priority_codes),
+            (mock_other_param | mock_no_program_param,
+             expected_mips_dict_processed_other_no),
         ]
     )
 def test_process_chart(params, expected_dict):
-    processed_chart = mips_api.process_chart(params, expected_mips_dict_raw, expected_omit_codes, other_code, no_program_code)
+    processed_chart = mips_api.process_chart(params,
+                                             expected_mips_dict_raw,
+                                             expected_omit_codes,
+                                             other_code,
+                                             no_program_code)
     assert processed_chart == expected_dict
 
 
@@ -387,18 +411,17 @@ def test_param_limit_int_err(params):
 
 
 @pytest.mark.parametrize(
-        "params,expected_dict",
+        "params,input_chart,expected_chart",
         [
-            ({}, expected_mips_dict_raw),
-            (mock_foo_param, expected_mips_dict_raw),
-            (mock_limit_param, expected_mips_dict_raw_limit),
-            (mock_filter_param, expected_mips_dict_processed),
-            (mock_limit_param | mock_filter_param, expected_mips_dict_processed_limit),
+            ({}, expected_mips_dict_processed, expected_mips_dict_processed),
+            (mock_foo_param, expected_mips_dict_raw, expected_mips_dict_raw),
+            (mock_limit_param, expected_mips_dict_raw, expected_mips_dict_raw_limit),
+            (mock_limit_param | mock_foo_param, expected_mips_dict_processed, expected_mips_dict_processed_limit),
         ]
     )
-def test_filter_chart(params, expected_dict):
-    processed_chart = mips_api.filter_chart(params, expected_mips_dict_raw, expected_omit_codes, other_code, no_program_code)
-    assert processed_chart == expected_dict
+def test_limit_chart(params, input_chart, expected_chart):
+    processed_chart = mips_api.limit_chart(params, input_chart)
+    assert processed_chart == expected_chart
 
 
 @pytest.mark.parametrize(
@@ -469,10 +492,16 @@ def test_lambda_handler_invalid_path(invalid_event, mocker):
     _test_with_env(mocker, invalid_event, 404, error='Invalid request path')
 
 
+def test_lambda_handler_empty_event(mocker):
+    '''Test empty event'''
+
+    _test_with_env(mocker, {}, 400, error='Invalid event: No path found: {}')
+
+
 def test_lambda_handler_accounts(accounts_event, mocker):
     '''Test chart-of-accounts event'''
 
-    _test_with_env(mocker, accounts_event, 200, body=expected_mips_dict_raw)
+    _test_with_env(mocker, accounts_event, 200, body=expected_mips_dict_processed)
 
 
 def test_lambda_handler_tags(tags_event, mocker):

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -145,6 +145,7 @@ expected_mips_dict_processed_limit = {
 
 expected_mips_dict_processed_priority_codes = {
     '000000': 'No Program',
+    '54321': 'Inactive',
     '123456': 'Program Part A',
     '234567': 'Other Program',
     '990300': 'Platform Infrastructure',
@@ -168,7 +169,7 @@ expected_tag_list_limit = [
 mock_foo_param = {'foo': 'bar'}
 mock_limit_param = {'limit': '2'}
 mock_other_param = {'show_other_code': 'true'}
-mock_priority_param = {'priority_codes': '234567'}
+mock_priority_param = {'priority_codes': '54321'}
 mock_inactive_param = {'show_inactive_codes': 'true'}
 mock_no_program_param = {'hide_no_program_code': 'true'}
 
@@ -352,7 +353,9 @@ def test_parse_codes(code_str, code_list):
             (mock_other_param, expected_mips_dict_processed_other),
             (mock_inactive_param, expected_mips_dict_processed_inactive),
             (mock_no_program_param, expected_mips_dict_processed_no),
-            (mock_priority_param, expected_mips_dict_processed_priority_codes),
+            (mock_priority_param, expected_mips_dict_processed),
+            (mock_priority_param | mock_inactive_param,
+             expected_mips_dict_processed_priority_codes),
             (mock_other_param | mock_no_program_param,
              expected_mips_dict_processed_other_no),
         ]
@@ -363,7 +366,7 @@ def test_process_chart(params, expected_dict):
                                              expected_omit_codes,
                                              other_code,
                                              no_program_code)
-    assert processed_chart == expected_dict
+    assert json.dumps(processed_chart) == json.dumps(expected_dict)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add a 'priority-codes' query-string parameter to move certain codes from the chart of accounts to the top of the output.

Replace the 'enable_code_filter' parameter with debug logging output and a refactor to ensure that the code processing always occurs. This also renames 'filter_chart' to 'limit_chart' for clarity as it now only processes the 'limit' parameter.
    
This will allow us to choose which tags will be listed in the Service Catalog drop-down menu.