### PR TITLE
[IT-3072] Add requests timeout

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -6,7 +6,7 @@ Description: >
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 15
+    Timeout: 30
 
 Parameters:
   AcmCertificateArn:


### PR DESCRIPTION
This lambda typically runs in 2-3 seconds, but has recently started hitting the 15-second AWS Lambda timeout.

Add a timeout when making requests to the upstream API to prevent the AWS Lambda timeout from killing the process before we can log out.

Also add a timeout to the logout command in case the first two requests are successful but the logout is hanging.
