### PR TITLE
[IT-3121] Enable key rotation

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -157,6 +157,7 @@ Resources:
     Type: AWS::KMS::Key
     Properties:
       Enabled: True
+      EnableKeyRotation: True
       KeyPolicy:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
Enable key rotation on the KMS key used by the lambda to access the secure parameters in SSM.
