### PR TITLE
[IT-4949] Add IAM auth to /balances endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ An AWS Lambda microservice providing limited read-only access to MIP Cloud.
 This microservice is designed to retrieve data using the MIP Cloud API and
 present the data in a useful format.
 
-Formats available:
+Data available:
 
-| API Route | Description                                                                 |
-| --------- | --------------------------------------------------------------------------- |
-| /accounts | A dictionary mapping the chart of program accounts to their friendly names. |
-| /balances | A CSV listing GL account balances, appropriate for FloQast consumption.     |
-| /tags     | A list of valid tag values for either `CostCenter` or `CostCenterOther`.    |
+| API Route | Description                                                                 | Auth Required |
+| --------- | --------------------------------------------------------------------------- | ------------- |
+| /accounts | A dictionary mapping the chart of program accounts to their friendly names. | No            |
+| /balances | A CSV listing GL account balances, appropriate for FloQast consumption.     | AWS IAM       |
+| /tags     | A list of valid tag values for either `CostCenter` or `CostCenterOther`.    | No            |
 
 Since we reach out to a third-party API across the internet, responses are
 cached to minimize interaction with the API and mitigate potential environmental
@@ -28,6 +28,12 @@ data to be stored in Cloudfront for a default of one day.
 
 In the event of a cache hit, Cloudfront will return the cached value without
 triggering an API gateway event.
+
+**Note on /balances endpoint:** The `/balances` endpoint requires AWS IAM
+authorization. Requests to this endpoint via CloudFront will receive a 403
+response directing callers to use the API Gateway URL directly with SigV4
+signing. The `/accounts` and `/tags` endpoints remain public and can be accessed
+via CloudFront.
 
 ### Chart of Accounts Behavior
 
@@ -127,17 +133,24 @@ other than today.
 
 ### Triggering
 
-The CloudFormation template will output all available endpoint URLs for
-triggering the lambda, e.g.: `https://abcxyz.cloudfront.net/accounts`
-`https://abcxyz.cloudfront.net/tags`
+The CloudFormation template outputs endpoint URLs for triggering the lambda.
 
-These URLs can be also constructed by appending the API Gateway paths to the
-CloudFormation domain.
+#### Public Endpoints (CloudFront)
 
-#### Origin URL
+The following endpoints are accessible via CloudFront without authentication:
 
-The CloudFormation template also outputs the origin URL behind the CloudFront
-distribution for debugging purposes.
+- `https://abcxyz.cloudfront.net/accounts`
+- `https://abcxyz.cloudfront.net/tags`
+
+These URLs can also be constructed by appending the API Gateway paths to the
+CloudFront domain.
+
+#### IAM-Authenticated Endpoint (API Gateway Direct)
+
+The `/balances` endpoint requires AWS IAM authorization and must be accessed via
+the API Gateway URL directly with SigV4 signing:
+
+- `https://<api-id>.execute-api.<region>.amazonaws.com/Prod/balances`
 
 ### Response Formats
 
@@ -157,6 +170,18 @@ E.g.:
   "54321": "Inactive",
   "990300": "Platform Infrastructure"
 }
+```
+
+#### /balances
+
+The `/balances` endpoint requires AWS IAM authorization and must be accessed via
+the API Gateway URL directly with SigV4 signing. The endpoint returns a CSV
+format suitable for FloQast consumption.
+
+CSV headers:
+
+```csv
+AccountNumber,AccountName,PeriodStart,PeriodEnd,StartBalance,Activity,EndBalance
 ```
 
 #### /tags
@@ -189,6 +214,22 @@ impact of the lambda cold starts by calling the lambda less frequently.
 
 If a bad response has been cached, it may need to be
 [manually invalidated through Cloudfront](https://aws.amazon.com/premiumsupport/knowledge-center/cloudfront-clear-cache/).
+
+### CloudFormation Outputs
+
+The CloudFormation template exports the following values for downstream
+integration:
+
+| Output                  | Description                                                                                            |
+| ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| ApiRouteChartOfAccounts | CloudFront URL for the `/accounts` endpoint (public)                                                   |
+| ApiRouteTrialBalances   | API Gateway URL for the `/balances` endpoint (IAM auth required)                                       |
+| ApiRouteValidTags       | CloudFront URL for the `/tags` endpoint (public)                                                       |
+| OriginUrl               | API Gateway base URL with stage (`/Prod/`), exported for downstream lambdas to construct endpoint URLs |
+| BalancesExecuteArn      | execute-api ARN for the `/balances` endpoint, exported for downstream IAM policies                     |
+| FunctionArn             | Lambda Function ARN                                                                                    |
+| FunctionRoleArn         | Implicit IAM Role created for function                                                                 |
+| CloudfrontDomain        | Domain name for the CloudFront distribution                                                            |
 
 ### S3 Cache
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ the API Gateway URL directly with SigV4 signing:
 
 - `https://<api-id>.execute-api.<region>.amazonaws.com/Prod/balances`
 
+For a detailed description of different ways access the URL with SigV4 signing,
+see [docs/balances-auth-example.md](docs/balances-auth-example.md).
+
 ### Response Formats
 
 #### /accounts

--- a/docs/balances-auth-example.md
+++ b/docs/balances-auth-example.md
@@ -32,20 +32,60 @@ the API Gateway URL directly.
 Navigate to the API Gateway -> API -> Resources, and select `/Prod/balances`.
 Navigate to the Test tab, enter query strings, and test.
 
-## Option 2: Python (requests + botocore SigV4)
+
+## Option 2: AWS CLI
+
+The `aws apigateway test-invoke-method` command invokes the endpoint directly
+through the API Gateway control plane, bypassing the need for SigV4 signing
+against the execute-api service. You need the REST API ID and the resource ID
+for `/balances`.
+
+```bash
+# Find the REST API ID
+aws apigateway get-rest-apis \
+  --query "items[?name=='<stack-name>'].id" \
+  --output text
+
+# Find the resource ID for /balances
+aws apigateway get-resources \
+--rest-api-id <api-id> \
+  --query "items[?path=='/balances'].id" \
+  --output text
+
+# Invoke the endpoint
+aws apigateway test-invoke-method \
+  --rest-api-id <api-id> \
+  --resource-id <resource-id> \
+  --http-method GET
+
+# Or with a query string parameter:
+aws apigateway test-invoke-method \
+  --rest-api-id <api-id> \
+  --resource-id <resource-id> \
+  --http-method GET \
+  --path-with-query-string "/balances?target_date=2026-03-15"
+```
+
+**Note:** This command requires `apigateway:TestInvokeMethod` permission rather
+than `execute-api:Invoke`. It is useful for quick testing but does not exercise
+the IAM authorizer — the request is always allowed if you have the control-plane
+permission.
+
+
+## Option 3: Python
 
 ```python
+import boto3
 import requests
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
-from botocore.session import Session
 
 # Configuration
 region = "us-east-1"
 api_url = "https://<api-id>.execute-api.us-east-1.amazonaws.com/Prod/balances"
 
 # Get credentials from the default credential chain
-session = Session()
+session = boto3.Session()
 credentials = session.get_credentials().get_frozen_credentials()
 
 # Create and sign the request
@@ -57,34 +97,6 @@ response = requests.get(api_url, headers=dict(request.headers))
 
 print(response.status_code)
 print(response.text)
-```
-
-## Option 3: Python (boto3 + urllib)
-
-```python
-import json
-from urllib.request import Request, urlopen
-from botocore.auth import SigV4Auth
-from botocore.awsrequest import AWSRequest
-import boto3
-
-# Configuration
-region = "us-east-1"
-api_url = "https://<api-id>.execute-api.us-east-1.amazonaws.com/Prod/balances"
-
-# Get credentials
-session = boto3.Session()
-credentials = session.get_credentials().get_frozen_credentials()
-
-# Sign the request
-request = AWSRequest(method="GET", url=api_url)
-SigV4Auth(credentials, "execute-api", region).add_auth(request)
-
-# Send using urllib (no extra dependency)
-req = Request(api_url, headers=dict(request.headers))
-with urlopen(req) as resp:
-    print(resp.status)
-    print(resp.read().decode())
 ```
 
 ## Troubleshooting

--- a/docs/balances-auth-example.md
+++ b/docs/balances-auth-example.md
@@ -1,0 +1,105 @@
+# Accessing the /balances Endpoint
+
+The `/balances` endpoint requires **AWS IAM authorization** (SigV4 signing).
+Requests via CloudFront will receive a `403 Forbidden` response — you must call
+the API Gateway URL directly.
+
+## Prerequisites
+
+1. **AWS credentials** with permission to invoke the endpoint. Your IAM
+   user or role needs the following policy:
+
+   ```json
+   {
+     "Effect": "Allow",
+     "Action": "execute-api:Invoke",
+     "Resource": "arn:aws:execute-api:<region>:<account-id>:<api-id>/Prod/GET/balances"
+   }
+   ```
+
+   The stack exports this ARN as `BalancesExecuteArn` for use in downstream
+   IAM policies.
+
+2. **The API Gateway URL** (not the CloudFront URL). The stack outputs this as
+   `ApiRouteTrialBalances`:
+
+   ```
+   https://<api-id>.execute-api.<region>.amazonaws.com/Prod/balances
+   ```
+
+## Option 1: AWS Console
+
+Navigate to the API Gateway -> API -> Resources, and select `/Prod/balances`.
+Navigate to the Test tab, enter query strings, and test.
+
+## Option 2: Python (requests + botocore SigV4)
+
+```python
+import requests
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.session import Session
+
+# Configuration
+region = "us-east-1"
+api_url = "https://<api-id>.execute-api.us-east-1.amazonaws.com/Prod/balances"
+
+# Get credentials from the default credential chain
+session = Session()
+credentials = session.get_credentials().get_frozen_credentials()
+
+# Create and sign the request
+request = AWSRequest(method="GET", url=api_url)
+SigV4Auth(credentials, "execute-api", region).add_auth(request)
+
+# Send the signed request
+response = requests.get(api_url, headers=dict(request.headers))
+
+print(response.status_code)
+print(response.text)
+```
+
+## Option 3: Python (boto3 + urllib)
+
+```python
+import json
+from urllib.request import Request, urlopen
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+import boto3
+
+# Configuration
+region = "us-east-1"
+api_url = "https://<api-id>.execute-api.us-east-1.amazonaws.com/Prod/balances"
+
+# Get credentials
+session = boto3.Session()
+credentials = session.get_credentials().get_frozen_credentials()
+
+# Sign the request
+request = AWSRequest(method="GET", url=api_url)
+SigV4Auth(credentials, "execute-api", region).add_auth(request)
+
+# Send using urllib (no extra dependency)
+req = Request(api_url, headers=dict(request.headers))
+with urlopen(req) as resp:
+    print(resp.status)
+    print(resp.read().decode())
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `403 Forbidden` with JSON body mentioning IAM | Using CloudFront URL | Use the API Gateway URL directly |
+| `403 Forbidden` / `Missing Authentication Token` | Request not signed | Sign with SigV4 (see examples above) |
+| `403 Forbidden` / `Access Denied` | IAM policy missing | Add `execute-api:Invoke` permission for the endpoint ARN |
+| `401 Unauthorized` | Expired credentials | Refresh your AWS session/credentials |
+
+## Notes
+
+- The `/accounts` and `/tags` endpoints remain **public** and are accessible
+  via CloudFront without authentication.
+- The `target_date` query parameter (ISO 8601 format, e.g. `2026-03-15`) is
+  optional. If omitted, the API uses today's date to determine the balance
+  period.

--- a/template.yaml
+++ b/template.yaml
@@ -55,6 +55,17 @@ Conditions:
   HasDnsNames: !Not [ !Equals [ !Join [ "", !Ref DnsNames ], "" ] ]
 
 Resources:
+  # Explicit API definition to enable IAM auth on /balances
+  MipsApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      Auth:
+        # Default is no auth (public); override per-endpoint below
+        DefaultAuthorizer: NONE
+      EndpointConfiguration:
+        Type: REGIONAL
+
   CacheBucket:
     Type: AWS::S3::Bucket
     Properties:
@@ -114,16 +125,21 @@ Resources:
           Properties:
             Path: '/accounts'
             Method: get
+            RestApiId: !Ref MipsApi
         TrialBalances:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
           Properties:
             Path: '/balances'
             Method: get
+            RestApiId: !Ref MipsApi
+            Auth:
+              Authorizer: AWS_IAM
         ValidTags:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
           Properties:
             Path: '/tags'
             Method: get
+            RestApiId: !Ref MipsApi
 
   FunctionRole:   # execute lambda function with this role
     Type: AWS::IAM::Role
@@ -158,9 +174,18 @@ Resources:
           CachePolicyId: !Ref CloudFrontCachePolicy
           TargetOriginId: LambdaOrigin
           ViewerProtocolPolicy: 'redirect-to-https'
+        CacheBehaviors:
+          # Block /balances at CloudFront — must use API Gateway directly with IAM auth
+          - PathPattern: '/balances*'
+            TargetOriginId: LambdaOrigin
+            ViewerProtocolPolicy: 'redirect-to-https'
+            CachePolicyId: !Ref CloudFrontCachePolicy
+            FunctionAssociations:
+              - EventType: viewer-request
+                FunctionARN: !GetAtt BlockBalancesFunction.FunctionMetadata.FunctionARN
         Origins:
           - Id: LambdaOrigin
-            DomainName: !Sub "${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com"
+            DomainName: !Sub "${MipsApi}.execute-api.${AWS::Region}.amazonaws.com"
             OriginPath: /Prod
             CustomOriginConfig:
               OriginProtocolPolicy: https-only
@@ -173,11 +198,30 @@ Resources:
           MinimumProtocolVersion: !If [ HasAcmCertificateArn, "TLSv1.2_2021", !Ref "AWS::NoValue" ]
           SslSupportMethod: !If [ HasAcmCertificateArn, "sni-only", !Ref "AWS::NoValue" ]
 
+  # CloudFront Function to return 403 for /balances requests via CloudFront
+  BlockBalancesFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      Name: !Sub "block-balances-${MipsApi}"
+      AutoPublish: true
+      FunctionConfig:
+        Comment: "Return 403 for /balances — must use API Gateway directly with IAM auth"
+        Runtime: cloudfront-js-2.0
+      FunctionCode: |
+        function handler(event) {
+          return {
+            statusCode: 403,
+            statusDescription: 'Forbidden',
+            headers: { 'content-type': { value: 'application/json' } },
+            body: '{"error": "The /balances endpoint requires IAM authentication. Use the API Gateway URL directly."}'
+          };
+        }
+
   CloudFrontCachePolicy:
     Type: AWS::CloudFront::CachePolicy
     Properties:
       CachePolicyConfig:
-        Name: !Sub "LambdaCache-${ServerlessRestApi}"
+        Name: !Sub "LambdaCache-${MipsApi}"
         MinTTL: 0
         MaxTTL: !Ref CacheTTL
         DefaultTTL: !Ref CacheTTL
@@ -243,21 +287,25 @@ Resources:
       AliasName: !Sub 'alias/${SsmAliasPrefix}-ssm-key'
 
 Outputs:
-  # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
-  # Find out more about other implicit resources you can reference within SAM
-  # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   ApiRouteChartOfAccounts:
     Description: "CloudFront URL for the full chart of accounts"
     Value: !Sub "https://${CloudFrontCache.DomainName}/accounts"
   ApiRouteTrialBalances:
-    Description: "CloudFront URL for trial balances"
-    Value: !Sub "https://${CloudFrontCache.DomainName}/balances"
+    Description: "API Gateway URL for trial balances (IAM auth required)"
+    Value: !Sub "https://${MipsApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/balances"
   ApiRouteValidTags:
     Description: "CloudFront URL for listing valid CostCenter tag values"
     Value: !Sub "https://${CloudFrontCache.DomainName}/tags"
   OriginUrl:
-    Description: "API Gateway origin URL with stage (for debugging)"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Description: "API Gateway base URL with stage, used by downstream lambdas to construct endpoint URLs"
+    Value: !Sub "https://${MipsApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-OriginUrl'
+  BalancesExecuteArn:
+    Description: "execute-api ARN for the /balances endpoint (IAM auth), used by downstream lambda IAM policies"
+    Value: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${MipsApi}/Prod/GET/balances"
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-BalancesExecuteArn'
   FunctionArn:
     Description: "Lambda Function ARN"
     Value: !GetAtt Function.Arn

--- a/template.yaml
+++ b/template.yaml
@@ -55,6 +55,17 @@ Conditions:
   HasDnsNames: !Not [ !Equals [ !Join [ "", !Ref DnsNames ], "" ] ]
 
 Resources:
+  # Explicit API definition to enable IAM auth on /balances
+  MipsApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      Auth:
+        # Default is no auth (public); override per-endpoint below
+        DefaultAuthorizer: NONE
+      EndpointConfiguration:
+        Type: REGIONAL
+
   CacheBucket:
     Type: AWS::S3::Bucket
     Properties:
@@ -114,16 +125,21 @@ Resources:
           Properties:
             Path: '/accounts'
             Method: get
+            RestApiId: !Ref MipsApi
         TrialBalances:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
           Properties:
             Path: '/balances'
             Method: get
+            RestApiId: !Ref MipsApi
+            Auth:
+              Authorizer: AWS_IAM
         ValidTags:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
           Properties:
             Path: '/tags'
             Method: get
+            RestApiId: !Ref MipsApi
 
   FunctionRole:   # execute lambda function with this role
     Type: AWS::IAM::Role
@@ -158,9 +174,18 @@ Resources:
           CachePolicyId: !Ref CloudFrontCachePolicy
           TargetOriginId: LambdaOrigin
           ViewerProtocolPolicy: 'redirect-to-https'
+        CacheBehaviors:
+          # Block /balances at CloudFront — must use API Gateway directly with IAM auth
+          - PathPattern: '/balances*'
+            TargetOriginId: LambdaOrigin
+            ViewerProtocolPolicy: 'redirect-to-https'
+            CachePolicyId: !Ref CloudFrontCachePolicy
+            FunctionAssociations:
+              - EventType: viewer-request
+                FunctionARN: !GetAtt BlockBalancesFunction.FunctionARN
         Origins:
           - Id: LambdaOrigin
-            DomainName: !Sub "${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com"
+            DomainName: !Sub "${MipsApi}.execute-api.${AWS::Region}.amazonaws.com"
             OriginPath: /Prod
             CustomOriginConfig:
               OriginProtocolPolicy: https-only
@@ -173,11 +198,30 @@ Resources:
           MinimumProtocolVersion: !If [ HasAcmCertificateArn, "TLSv1.2_2021", !Ref "AWS::NoValue" ]
           SslSupportMethod: !If [ HasAcmCertificateArn, "sni-only", !Ref "AWS::NoValue" ]
 
+  # CloudFront Function to return 403 for /balances requests via CloudFront
+  BlockBalancesFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      Name: !Sub "block-balances-${MipsApi}"
+      AutoPublish: true
+      FunctionConfig:
+        Comment: "Return 403 for /balances — must use API Gateway directly with IAM auth"
+        Runtime: cloudfront-js-2.0
+      FunctionCode: |
+        function handler(event) {
+          return {
+            statusCode: 403,
+            statusDescription: 'Forbidden',
+            headers: { 'content-type': { value: 'application/json' } },
+            body: '{"error": "The /balances endpoint requires IAM authentication. Use the API Gateway URL directly."}'
+          };
+        }
+
   CloudFrontCachePolicy:
     Type: AWS::CloudFront::CachePolicy
     Properties:
       CachePolicyConfig:
-        Name: !Sub "LambdaCache-${ServerlessRestApi}"
+        Name: !Sub "LambdaCache-${MipsApi}"
         MinTTL: 0
         MaxTTL: !Ref CacheTTL
         DefaultTTL: !Ref CacheTTL
@@ -243,21 +287,25 @@ Resources:
       AliasName: !Sub 'alias/${SsmAliasPrefix}-ssm-key'
 
 Outputs:
-  # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
-  # Find out more about other implicit resources you can reference within SAM
-  # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   ApiRouteChartOfAccounts:
     Description: "CloudFront URL for the full chart of accounts"
     Value: !Sub "https://${CloudFrontCache.DomainName}/accounts"
   ApiRouteTrialBalances:
-    Description: "CloudFront URL for trial balances"
-    Value: !Sub "https://${CloudFrontCache.DomainName}/balances"
+    Description: "API Gateway URL for trial balances (IAM auth required)"
+    Value: !Sub "https://${MipsApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/balances"
   ApiRouteValidTags:
     Description: "CloudFront URL for listing valid CostCenter tag values"
     Value: !Sub "https://${CloudFrontCache.DomainName}/tags"
   OriginUrl:
-    Description: "API Gateway origin URL with stage (for debugging)"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Description: "API Gateway base URL with stage, used by downstream lambdas to construct endpoint URLs"
+    Value: !Sub "https://${MipsApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-OriginUrl'
+  BalancesExecuteArn:
+    Description: "execute-api ARN for the /balances endpoint (IAM auth), used by downstream lambda IAM policies"
+    Value: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${MipsApi}/Prod/GET/balances"
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-BalancesExecuteArn'
   FunctionArn:
     Description: "Lambda Function ARN"
     Value: !GetAtt Function.Arn

--- a/template.yaml
+++ b/template.yaml
@@ -165,6 +165,7 @@ Resources:
             RestApiId: !Ref MipsApi
             Auth:
               Authorizer: AWS_IAM
+              InvokeRole: NONE
         ValidTags:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
           Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -65,6 +65,37 @@ Resources:
         DefaultAuthorizer: NONE
       EndpointConfiguration:
         Type: REGIONAL
+      AccessLogSetting:
+        DestinationArn: !GetAtt ApiAccessLogGroup.Arn
+        Format: >-
+          {"requestId":"$context.requestId",
+          "ip":"$context.identity.sourceIp",
+          "caller":"$context.identity.caller",
+          "user":"$context.identity.user",
+          "requestTime":"$context.requestTime",
+          "httpMethod":"$context.httpMethod",
+          "path":"$context.path",
+          "status":"$context.status",
+          "protocol":"$context.protocol",
+          "responseLength":"$context.responseLength",
+          "authenticateStatus":"$context.authenticate.status",
+          "authenticateError":"$context.authenticate.error",
+          "authorizeStatus":"$context.authorize.status",
+          "authorizeError":"$context.authorize.error",
+          "integrationStatus":"$context.integration.status",
+          "integrationError":"$context.integrationErrorMessage",
+          "error":"$context.error.messageString"}
+      MethodSettings:
+        - ResourcePath: '/*'
+          HttpMethod: '*'
+          LoggingLevel: INFO
+          DataTraceEnabled: true
+
+  ApiAccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/apigateway/${AWS::StackName}-access-logs'
+      RetentionInDays: 30
 
   CacheBucket:
     Type: AWS::S3::Bucket
@@ -287,6 +318,9 @@ Resources:
       AliasName: !Sub 'alias/${SsmAliasPrefix}-ssm-key'
 
 Outputs:
+  ApiAccessLogGroupArn:
+    Description: "CloudWatch Log Group for API Gateway access logs"
+    Value: !GetAtt ApiAccessLogGroup.Arn
   ApiRouteChartOfAccounts:
     Description: "CloudFront URL for the full chart of accounts"
     Value: !Sub "https://${CloudFrontCache.DomainName}/accounts"


### PR DESCRIPTION
Switch from implicit ServerlessRestApi to an explicit API Gateway resource to enable per-endpoint auth.
The /balances endpoint now requires AWS_IAM
authorization while /accounts and /tags remain public.

A CloudFront Function returns 403 for /balances
requests via CloudFront, directing callers to use
the API Gateway URL directly with SigV4 signing.

New exports:
- OriginUrl: API Gateway base URL for downstream lambdas to construct endpoint URLs.
- BalancesExecuteArn: pre-built execute-api ARN for downstream IAM policies.